### PR TITLE
fix: update default package values in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,9 @@ on:
 
 env:
   # Package-specific configuration - customize these for each package
-  PACKAGE_NAME: ${{ vars.PACKAGE_NAME || 'wp-utility' }}
-  PACKAGE_DISPLAY_NAME: ${{ vars.PACKAGE_DISPLAY_NAME || 'WP Utility' }}
-  COMPOSER_NAMESPACE: ${{ vars.COMPOSER_NAMESPACE || 'builtnorth/wp-utility' }}
+  PACKAGE_NAME: ${{ vars.PACKAGE_NAME || 'wp-baseline' }}
+  PACKAGE_DISPLAY_NAME: ${{ vars.PACKAGE_DISPLAY_NAME || 'WP Baseline' }}
+  COMPOSER_NAMESPACE: ${{ vars.COMPOSER_NAMESPACE || 'builtnorth/wp-baseline' }}
 
 jobs:
   release:


### PR DESCRIPTION
- Set correct package-specific defaults for PACKAGE_NAME
- Set correct package-specific defaults for PACKAGE_DISPLAY_NAME
- Set correct package-specific defaults for COMPOSER_NAMESPACE
- Ensures each package creates releases with proper naming