### PR TITLE
fix: pass secrets to reusable CI workflow

### DIFF
--- a/.github/workflows/scheduled-ci.yml
+++ b/.github/workflows/scheduled-ci.yml
@@ -9,3 +9,4 @@ on:
 jobs:
   scheduled-ci:
     uses: builtnorth/.github/.github/workflows/composer-package-ci.yml@main
+    secrets: inherit

--- a/.github/workflows/scheduled-ci.yml
+++ b/.github/workflows/scheduled-ci.yml
@@ -10,3 +10,5 @@ jobs:
   scheduled-ci:
     uses: builtnorth/.github/.github/workflows/composer-package-ci.yml@main
     secrets: inherit
+    with:
+      composer-repository-profile: coding-standards-only

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,3 +9,5 @@ jobs:
   ci:
     uses: builtnorth/.github/.github/workflows/composer-package-ci.yml@main
     secrets: inherit
+    with:
+      composer-repository-profile: coding-standards-only

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,3 +8,4 @@ on:
 jobs:
   ci:
     uses: builtnorth/.github/.github/workflows/composer-package-ci.yml@main
+    secrets: inherit


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to ensure that secrets are properly inherited by jobs that use reusable workflows. This change is necessary for secure access to secrets within these jobs.

Workflow configuration updates:

* Added `secrets: inherit` to the `scheduled-ci` job in `.github/workflows/scheduled-ci.yml` to allow the job to access repository secrets when using the reusable workflow.
* Added `secrets: inherit` to the `ci` job in `.github/workflows/tests.yml` to enable secret inheritance for this job as well.